### PR TITLE
fix: use consistent config path for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,8 @@ leap network check
 ## 📁 Files & Configuration
 
 ### Important Files
-- **Configuration**: `~/.config/input-leap/server.conf`
+- **Client Configuration**: `~/.config/input-leap/server.conf`
+- **Server Configuration**: `~/.config/input-leap/leap-server.conf`
 - **Logs**: `~/.cache/input-leap/client.log`
 - **Service**: `~/.config/systemd/user/input-leap.service`
 

--- a/bin/leap-server
+++ b/bin/leap-server
@@ -15,7 +15,8 @@ readonly CYAN='\033[0;36m'
 readonly NC='\033[0m'
 
 # Paths
-readonly CONFIG_DIR="$HOME/.config/InputLeap"
+# Use consistent lowercase config directory to match client scripts
+readonly CONFIG_DIR="$HOME/.config/input-leap"
 readonly CONFIG_FILE="$CONFIG_DIR/leap-server.conf"
 readonly LOG_FILE="$HOME/.cache/input-leap/server.log"
 readonly PID_FILE="/tmp/input-leap-server.pid"


### PR DESCRIPTION
## Summary
- use lowercase config directory for server to align with client scripts
- document server config file location in README

## Testing
- `bin/leap-server --help`
- `bin/leap-client --help`
- `bin/validate-environment` *(fails: ip: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896705b70c88322adf05fb55b3e578a